### PR TITLE
Förhindra överlappande kolumner

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,7 @@ h1 {
     padding: 20px;
     margin: 20px;
     column-count: 9;
+    column-width: 7em;
 }
 
 #result span {


### PR DESCRIPTION
Den här fixen ska förhindra att säsongskortsnumrena överlappar varandra på mindre skärmar